### PR TITLE
feat(picker:font leading/lineheight): Dynamically pick line height

### DIFF
--- a/mappings/modes.lua
+++ b/mappings/modes.lua
@@ -159,6 +159,7 @@ local key_tables = {
     { "t", require("picker.colorscheme"):pick(), "theme picker" },
     { "s", require("picker.font-size"):pick(), "fontsize picker" },
     { "f", require("picker.font"):pick(), "font picker" },
+    { "l", require("picker.leading"):pick(), "line height picker" },
   }, -- }}}
 }
 

--- a/picker/assets/leadings/leadings.lua
+++ b/picker/assets/leadings/leadings.lua
@@ -1,0 +1,24 @@
+---@module "picker.assets.font-sizes.font-sizes"
+---@author sravioli
+---@license GNU-GPLv3
+
+---@class PickList
+local M = {}
+
+M.get = function()
+  local leadings_list = { { label = "Reset Line Height to Default", id = "Reset" } }
+  for i = 0.9, 1.4, 0.1 do
+    table.insert(leadings_list, { label = i .. "x", id = tostring(i) })
+  end
+  return leadings_list
+end
+
+M.activate = function(config, opts)
+  if opts.id == "Reset" then
+    config.line_height = nil
+  else
+    config.line_height = tonumber(opts.id)
+  end
+end
+
+return M

--- a/picker/leading.lua
+++ b/picker/leading.lua
@@ -1,0 +1,15 @@
+---@module "picker.leadings"
+---@author sravioli, akthe-at
+---@license GNU-GPLv3
+
+local Picker = require("utils").class.picker
+
+return Picker.new {
+  title = "Font Leadings(line height) Picker",
+  subdir = "leadings",
+  fuzzy = false,
+  comp = function(a, b)
+    local label = "Reset Line Height to Default"
+    return (a.label == label) or (b.label ~= label and a.label < b.label)
+  end,
+}


### PR DESCRIPTION


## Proposed changes

I find this picker to be very useful when moving between workspaces with different size monitors/screens. I didn't know how you might want this contribution but decided to throw it in with your giant refactor... Feel free to rename to anyway that you see fits as well!

## Types of changes

What types of changes does your code introduce to the Config?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask._

- [x] I have read the [CONTRIBUTING](https://github.com/sravioli/wezterm/blob/main/.github/CONTRIBUTING.md)
  doc
- [ ] I have added the necessary documentation (if appropriate)


