### PR TITLE
fix: battery on desktops

### DIFF
--- a/config/gpu.lua
+++ b/config/gpu.lua
@@ -5,12 +5,10 @@ Config.webgpu_force_fallback_adapter = false
 
 ---switch to low power mode when battery is low
 ---@diagnostic disable-next-line: undefined-field
-local battery_charge = require("wezterm").battery_info()[1].state_of_charge
-if battery_charge < 0.35 then
-  Config.webgpu_power_preference = "LowPower"
-else
-  Config.webgpu_power_preference = "HighPerformance"
-end
+local battery = require("wezterm").battery_info()[1]
+Config.webgpu_power_preference = (battery and battery.state_of_charge < 0.35)
+    and "LowPower"
+  or "HighPerformance"
 
 Config.webgpu_preferred_adapter = require("utils.gpu"):pick_best()
 

--- a/events/update-status.lua
+++ b/events/update-status.lua
@@ -140,12 +140,14 @@ wt.on("update-status", function(window, pane)
   --~~ {{{3: battery cells
 
   local battery = wt.battery_info()[1]
-  battery.charge_lvl = battery.state_of_charge * 100
-  battery.charge_lvl_round = mt.toint(mt.mround(battery.charge_lvl, 10))
-  battery.ico = icon.Bat[battery.state][tostring(battery.charge_lvl_round)]
-  battery.lvl = tonumber(floor(battery.charge_lvl + 0.5)) .. "%"
-  battery.full = ("%s %s"):format(battery.lvl, battery.ico)
-  battery.cells = { battery.full, battery.lvl, battery.ico }
+  if battery then
+    battery.charge_lvl = battery.state_of_charge * 100
+    battery.charge_lvl_round = mt.toint(mt.mround(battery.charge_lvl, 10))
+    battery.ico = icon.Bat[battery.state][tostring(battery.charge_lvl_round)]
+    battery.lvl = tonumber(floor(battery.charge_lvl + 0.5)) .. "%"
+    battery.full = ("%s %s"):format(battery.lvl, battery.ico)
+    battery.cells = { battery.full, battery.lvl, battery.ico }
+  end
   --~~ }}}
 
   --~~ {{{3: datime cells
@@ -176,7 +178,10 @@ wt.on("update-status", function(window, pane)
   local fancy_bg = Config.window_frame.active_titlebar_bg
   local last_fg = Config.use_fancy_tab_bar and fancy_bg or theme.tab_bar.background
 
-  local sets = { cwd_cells, hostname_cells, time_cells, battery.cells }
+  local sets = { cwd_cells, hostname_cells, time_cells }
+  if battery then
+    tinsert(sets, battery.cells)
+  end
 
   local function compute_width(combination, sep_width, pad_width)
     local total_width = 0


### PR DESCRIPTION
## Proposed changes
The config looked extremely cool and wanted to try it out, so i've cloned the config and got the following errors:

```
04:11:43.695 ERROR wezterm_gui::termwindow > while processing update-status event: runtime error: C:\Users\bida\.config\wezterm/events\update-status.lua:29: attempt to index a nil value (local 'theme')
stack traceback:
        C:\Users\bida\.config\wezterm/events\update-status.lua:29: in function <C:\Users\bida\.config\wezterm/events\update-status.lua:22>
04:11:43.696 ERROR wezterm_gui::termwindow > while processing update-status event: runtime error: C:\Users\bida\.config\wezterm/events\update-status.lua:29: attempt to index a nil value (local 'theme')
```
The configuration didn't load at all. After further investigations it seems that the error messages are misleading and the culprit was actually in config/gpu.lua. On desktop computers without battery `require("wezterm").battery_info()` will return `{}` and the whole config will crash on the indexing `require("wezterm").battery_info()[1]`. 

After this change the config worked and I've looked at other places where the battery was used and noticed that the status was not showing either for the same reason.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/sravioli/wezterm/blob/main/.github/contributing.md) doc
- [ ] I have added the necessary documentation (if appropriate)

## Further comments

I don't have a laptop available to test that everything is fine.
